### PR TITLE
feat: add bus stops and bus routes management, booking 

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,6 +24,8 @@
         "axios": "^1.7.9",
         "backend": "file:",
         "bcrypt": "^5.1.1",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.1",
         "dayjs": "^1.11.13",
         "joi": "^17.13.3",
         "jsonwebtoken": "^9.0.2",
@@ -2296,6 +2298,12 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/validator": {
+      "version": "13.12.2",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.2.tgz",
+      "integrity": "sha512-6SlHBzUW8Jhf3liqrGGXyTJSIFe4nqlJ5A5KaMZ2l/vbM3Wh3KSybots/wfWVzNLK4D1NZluDlSQIbIEPx6oyA==",
+      "license": "MIT"
+    },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
@@ -3497,6 +3505,23 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "license": "MIT"
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.1.tgz",
+      "integrity": "sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/validator": "^13.11.8",
+        "libphonenumber-js": "^1.10.53",
+        "validator": "^13.9.0"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -6587,6 +6612,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.20.tgz",
+      "integrity": "sha512-/ipwAMvtSZRdiQBHqW1qxqeYiBMzncOQLVA+62MWYr7N4m7Q2jqpJ0WgT7zlOEOpyLRSqrMXidbJpC0J77AaKA==",
+      "license": "MIT"
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -9404,6 +9435,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,6 +36,8 @@
     "axios": "^1.7.9",
     "backend": "file:",
     "bcrypt": "^5.1.1",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
     "dayjs": "^1.11.13",
     "joi": "^17.13.3",
     "jsonwebtoken": "^9.0.2",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -18,6 +18,8 @@ import { TripModule } from 'src/modules/trip/trip.module';
 import { BookingModule } from 'src/modules/booking/booking.module';
 import { SearchModule } from 'src/modules/search/search.module';
 import { CheckoutModule } from 'src/modules/checkout/checkout.module';
+import { BusStopModule } from './modules/bus-stop/bus-stop.module';
+import { BusRouteModule } from './modules/bus-route/bus-route.module';
 
 @Module({
   imports: [
@@ -44,7 +46,9 @@ import { CheckoutModule } from 'src/modules/checkout/checkout.module';
     TripModule,
     SearchModule,
     BookingModule,
-    CheckoutModule
+    CheckoutModule,
+    BusStopModule,
+    BusRouteModule
   ],
   controllers: [AppController],
   providers: [AppService, AppGateway],

--- a/backend/src/config/swagger.config.ts
+++ b/backend/src/config/swagger.config.ts
@@ -16,6 +16,8 @@ export const swaggerConfig = new DocumentBuilder()
     .addTag('scenic-routes', 'Scenic Routes management')
     .addTag('driver-schedules', 'Driver schedule management')
     .addTag('trip', 'Trip management')
+    .addTag('bus-stops', 'Bus Stop management') 
+    .addTag('bus-routes', 'Bus Route management')
 
     .addBearerAuth(
         { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },

--- a/backend/src/modules/bus-route/bus-route.controller.ts
+++ b/backend/src/modules/bus-route/bus-route.controller.ts
@@ -1,0 +1,176 @@
+import { Controller, Get, Post, Put, Delete, Body, Param, UseGuards, Inject } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { AuthGuard } from '../auth/auth.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { RolesGuard } from '../auth/role.guard';
+import { UserRole } from '../../share/enums';
+import { BUS_ROUTE_SERVICE } from './bus-route.di-token';
+import { IBusRouteService } from './bus-route.port';
+import { CreateBusRouteDto, UpdateBusRouteDto } from './bus-route.dto';
+import { ValidationErrorResponse } from 'src/common/swagger/responses';
+
+@ApiTags('bus-routes')
+@Controller('bus-routes')
+@UseGuards(AuthGuard, RolesGuard)
+@ApiBearerAuth('authorization')
+export class BusRouteController {
+    constructor(
+        @Inject(BUS_ROUTE_SERVICE)
+        private readonly busRouteService: IBusRouteService
+    ) {}
+
+    @Post()
+    @Roles(UserRole.ADMIN)
+    @ApiOperation({ summary: 'Create new bus route' })
+    @ApiResponse({ 
+        status: 201, 
+        description: 'Bus route created successfully',
+        type: CreateBusRouteDto 
+    })
+    @ApiResponse({ 
+        status: 400, 
+        description: 'Validation failed',
+        type: ValidationErrorResponse 
+    })
+    @ApiResponse({ 
+        status: 401, 
+        description: 'Unauthorized' 
+    })
+    @ApiResponse({ 
+        status: 403, 
+        description: 'Forbidden - Admin only' 
+    })
+    async createRoute(@Body() dto: CreateBusRouteDto) {
+        return await this.busRouteService.createRoute(dto);
+    }
+
+    @Get()
+    @ApiOperation({ summary: 'Get all bus routes' })
+    @ApiResponse({ 
+        status: 200, 
+        description: 'List of all bus routes',
+        type: [CreateBusRouteDto]
+    })
+    @ApiResponse({ 
+        status: 401, 
+        description: 'Unauthorized' 
+    })
+    async getAllRoutes() {
+        return await this.busRouteService.getAllRoutes();
+    }
+
+    @Get(':id')
+    @ApiOperation({ summary: 'Get bus route by id' })
+    @ApiResponse({ 
+        status: 200, 
+        description: 'Bus route details',
+        type: CreateBusRouteDto
+    })
+    @ApiResponse({ 
+        status: 401, 
+        description: 'Unauthorized' 
+    })
+    @ApiResponse({ 
+        status: 404, 
+        description: 'Bus route not found' 
+    })
+    async getRouteById(@Param('id') id: string) {
+        return await this.busRouteService.getRouteById(id);
+    }
+
+    @Put(':id')
+    @Roles(UserRole.ADMIN)
+    @ApiOperation({ summary: 'Update bus route' })
+    @ApiResponse({ 
+        status: 200, 
+        description: 'Bus route updated successfully',
+        type: UpdateBusRouteDto
+    })
+    @ApiResponse({ 
+        status: 400, 
+        description: 'Validation failed',
+        type: ValidationErrorResponse 
+    })
+    @ApiResponse({ 
+        status: 401, 
+        description: 'Unauthorized' 
+    })
+    @ApiResponse({ 
+        status: 403, 
+        description: 'Forbidden - Admin only' 
+    })
+    @ApiResponse({ 
+        status: 404, 
+        description: 'Bus route not found' 
+    })
+    async updateRoute(
+        @Param('id') id: string,
+        @Body() dto: UpdateBusRouteDto
+    ) {
+        return await this.busRouteService.updateRoute(id, dto);
+    }
+
+    @Delete(':id')
+    @Roles(UserRole.ADMIN)
+    @ApiOperation({ summary: 'Delete bus route' })
+    @ApiResponse({ 
+        status: 200, 
+        description: 'Bus route deleted successfully' 
+    })
+    @ApiResponse({ 
+        status: 401, 
+        description: 'Unauthorized' 
+    })
+    @ApiResponse({ 
+        status: 403, 
+        description: 'Forbidden - Admin only' 
+    })
+    @ApiResponse({ 
+        status: 404, 
+        description: 'Bus route not found' 
+    })
+    async deleteRoute(@Param('id') id: string) {
+        await this.busRouteService.deleteRoute(id);
+        return { message: 'Bus route deleted successfully' };
+    }
+
+    @Post('calculate-fare')
+    @ApiOperation({ summary: 'Calculate fare for route' })
+    @ApiResponse({ 
+        status: 200, 
+        description: 'Fare calculation result',
+        schema: {
+            type: 'object',
+            properties: {
+                fare: {
+                    type: 'number',
+                    example: 50000
+                }
+            }
+        }
+    })
+    @ApiResponse({ 
+        status: 400, 
+        description: 'Invalid input' 
+    })
+    @ApiResponse({ 
+        status: 404, 
+        description: 'Route or stops not found' 
+    })
+    async calculateFare(
+        @Body() data: {
+            routeId: string;
+            fromStopId: string;
+            toStopId: string;
+            numberOfSeats: number;
+        }
+    ) {
+        const fare = await this.busRouteService.calculateFare(
+            data.routeId,
+            data.fromStopId,
+            data.toStopId,
+            data.numberOfSeats
+        );
+        return { fare };
+    }
+}

--- a/backend/src/modules/bus-route/bus-route.di-token.ts
+++ b/backend/src/modules/bus-route/bus-route.di-token.ts
@@ -1,0 +1,2 @@
+export const BUS_ROUTE_REPOSITORY = Symbol('BusRouteRepository');
+export const BUS_ROUTE_SERVICE = Symbol('BusRouteService');

--- a/backend/src/modules/bus-route/bus-route.dto.ts
+++ b/backend/src/modules/bus-route/bus-route.dto.ts
@@ -1,0 +1,209 @@
+import { IsString, IsNotEmpty, IsNumber, IsArray, IsEnum, IsMongoId, ValidateNested, Min } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export class PositionDto {
+    @ApiProperty({
+        description: 'Latitude coordinate',
+        example: 21.028511
+    })
+    @IsNumber()
+    lat: number;
+
+    @ApiProperty({
+        description: 'Longitude coordinate',
+        example: 105.804817
+    })
+    @IsNumber()
+    lng: number;
+}
+
+export class RouteStopDto {
+    @ApiProperty({
+        description: 'Bus stop ID',
+        example: '507f1f77bcf86cd799439011'
+    })
+    @IsMongoId()
+    stopId: string;
+
+    @ApiProperty({
+        description: 'Order index of the stop in route',
+        example: 1
+    })
+    @IsNumber()
+    @Min(0)
+    orderIndex: number;
+
+    @ApiProperty({
+        description: 'Distance from start point (km)',
+        example: 5.2
+    })
+    @IsNumber()
+    @Min(0)
+    distanceFromStart: number;
+
+    @ApiProperty({
+        description: 'Estimated time from start point (minutes)',
+        example: 15
+    })
+    @IsNumber()
+    @Min(0)
+    estimatedTime: number;
+}
+
+export class CreateBusRouteDto {
+    @ApiProperty({
+        description: 'Name of the bus route',
+        example: 'Route 01: Vincom - Times City'
+    })
+    @IsString()
+    @IsNotEmpty()
+    name: string;
+
+    @ApiProperty({
+        description: 'Description of the route',
+        required: false,
+        example: 'Direct route connecting Vincom Center and Times City'
+    })
+    @IsString()
+    description?: string;
+
+    @ApiProperty({
+        description: 'List of stops in the route',
+        type: [RouteStopDto]
+    })
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => RouteStopDto)
+    stops: RouteStopDto[];
+
+    @ApiProperty({
+        description: 'Route coordinates',
+        type: [PositionDto]
+    })
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => PositionDto)
+    routeCoordinates: PositionDto[];
+
+    @ApiProperty({
+        description: 'Total distance of route (km)',
+        example: 12.5
+    })
+    @IsNumber()
+    @Min(0)
+    totalDistance: number;
+
+    @ApiProperty({
+        description: 'Estimated duration (minutes)',
+        example: 45
+    })
+    @IsNumber()
+    @Min(0)
+    estimatedDuration: number;
+
+    @ApiProperty({
+        description: 'Vehicle category ID',
+        example: '507f1f77bcf86cd799439011'
+    })
+    @IsMongoId()
+    vehicleCategory: string;
+
+    @ApiProperty({
+        description: 'Route status',
+        enum: ['active', 'inactive'],
+        example: 'active'
+    })
+    @IsEnum(['active', 'inactive'])
+    status: string;
+
+    @ApiProperty({
+        description: 'Base price for the route',
+        example: 50000
+    })
+    @IsNumber()
+    @Min(0)
+    basePrice: number;
+}
+
+export class UpdateBusRouteDto {
+    @ApiProperty({
+        description: 'Name of the bus route',
+        required: false,
+        example: 'Route 01: Vincom - Times City'
+    })
+    @IsString()
+    name?: string;
+
+    @ApiProperty({
+        description: 'Description of the route',
+        required: false,
+        example: 'Direct route connecting Vincom Center and Times City'
+    })
+    @IsString()
+    description?: string;
+
+    @ApiProperty({
+        description: 'List of stops in the route',
+        required: false,
+        type: [RouteStopDto]
+    })
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => RouteStopDto)
+    stops?: RouteStopDto[];
+
+    @ApiProperty({
+        description: 'Route coordinates',
+        required: false,
+        type: [PositionDto]
+    })
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => PositionDto)
+    routeCoordinates?: PositionDto[];
+
+    @ApiProperty({
+        description: 'Total distance of route (km)',
+        required: false,
+        example: 12.5
+    })
+    @IsNumber()
+    @Min(0)
+    totalDistance?: number;
+
+    @ApiProperty({
+        description: 'Estimated duration (minutes)',
+        required: false,
+        example: 45
+    })
+    @IsNumber()
+    @Min(0)
+    estimatedDuration?: number;
+
+    @ApiProperty({
+        description: 'Vehicle category ID',
+        required: false,
+        example: '507f1f77bcf86cd799439011'
+    })
+    @IsMongoId()
+    vehicleCategory?: string;
+
+    @ApiProperty({
+        description: 'Route status',
+        required: false,
+        enum: ['active', 'inactive'],
+        example: 'active'
+    })
+    @IsEnum(['active', 'inactive'])
+    status?: string;
+
+    @ApiProperty({
+        description: 'Base price for the route',
+        required: false,
+        example: 50000
+    })
+    @IsNumber()
+    @Min(0)
+    basePrice?: number;
+}

--- a/backend/src/modules/bus-route/bus-route.module.ts
+++ b/backend/src/modules/bus-route/bus-route.module.ts
@@ -1,0 +1,37 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { BusRoute, BusRouteSchema } from './bus-route.schema';
+import { BusRouteController } from './bus-route.controller';
+import { BusRouteService } from './bus-route.service';
+import { BusRouteRepository } from './bus-route.repo';
+import { BUS_ROUTE_REPOSITORY, BUS_ROUTE_SERVICE } from './bus-route.di-token';
+import { KeytokenModule } from '../keytoken/keytoken.module';
+import { ShareModule } from 'src/share/share.module';
+
+const dependencies = [
+    {
+        provide: BUS_ROUTE_REPOSITORY,
+        useClass: BusRouteRepository
+    },
+    {
+        provide: BUS_ROUTE_SERVICE,
+        useClass: BusRouteService
+    }
+];
+
+@Module({
+    imports: [
+        MongooseModule.forFeature([
+            {
+                name: BusRoute.name,
+                schema: BusRouteSchema
+            }
+        ]),
+        KeytokenModule,
+        ShareModule
+    ],
+    controllers: [BusRouteController],
+    providers: [...dependencies],
+    exports: [...dependencies]
+})
+export class BusRouteModule {}

--- a/backend/src/modules/bus-route/bus-route.port.ts
+++ b/backend/src/modules/bus-route/bus-route.port.ts
@@ -1,0 +1,19 @@
+import { BusRouteDocument } from './bus-route.schema';
+import { CreateBusRouteDto, UpdateBusRouteDto } from './bus-route.dto';
+
+export interface IBusRouteRepository {
+    create(dto: CreateBusRouteDto): Promise<BusRouteDocument>;
+    findAll(): Promise<BusRouteDocument[]>;
+    findById(id: string): Promise<BusRouteDocument>;
+    update(id: string, dto: UpdateBusRouteDto): Promise<BusRouteDocument>;
+    delete(id: string): Promise<void>;
+}
+
+export interface IBusRouteService {
+    createRoute(dto: CreateBusRouteDto): Promise<BusRouteDocument>;
+    getAllRoutes(): Promise<BusRouteDocument[]>;
+    getRouteById(id: string): Promise<BusRouteDocument>;
+    updateRoute(id: string, dto: UpdateBusRouteDto): Promise<BusRouteDocument>;
+    deleteRoute(id: string): Promise<void>;
+    calculateFare(routeId: string, fromStopId: string, toStopId: string, numberOfSeats: number): Promise<number>;
+}

--- a/backend/src/modules/bus-route/bus-route.repo.ts
+++ b/backend/src/modules/bus-route/bus-route.repo.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { BusRoute, BusRouteDocument } from './bus-route.schema';
+import { IBusRouteRepository } from './bus-route.port';
+import { CreateBusRouteDto, UpdateBusRouteDto } from './bus-route.dto';
+
+@Injectable()
+export class BusRouteRepository implements IBusRouteRepository {
+    constructor(
+        @InjectModel(BusRoute.name)
+        private readonly busRouteModel: Model<BusRoute>
+    ) {}
+
+    async create(dto: CreateBusRouteDto): Promise<BusRouteDocument> {
+        const busRoute = new this.busRouteModel(dto);
+        return await busRoute.save();
+    }
+
+    async findAll(): Promise<BusRouteDocument[]> {
+        return await this.busRouteModel.find()
+            .populate('stops.stopId')
+            .populate('vehicleCategory')
+            .exec();
+    }
+
+    async findById(id: string): Promise<BusRouteDocument> {
+        return await this.busRouteModel.findById(id)
+            .populate('stops.stopId')
+            .populate('vehicleCategory')
+            .exec();
+    }
+
+    async update(id: string, dto: UpdateBusRouteDto): Promise<BusRouteDocument> {
+        return await this.busRouteModel.findByIdAndUpdate(id, dto, { new: true })
+            .populate('stops.stopId')
+            .populate('vehicleCategory')
+            .exec();
+    }
+
+    async delete(id: string): Promise<void> {
+        await this.busRouteModel.findByIdAndDelete(id).exec();
+    }
+}

--- a/backend/src/modules/bus-route/bus-route.schema.ts
+++ b/backend/src/modules/bus-route/bus-route.schema.ts
@@ -1,0 +1,60 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument, Types } from 'mongoose';
+
+export type BusRouteDocument = HydratedDocument<BusRoute>;
+
+@Schema({ _id: false })
+class Position {
+    @Prop({ required: true, type: Number })
+    lat: number;
+
+    @Prop({ required: true, type: Number })
+    lng: number;
+}
+
+@Schema({ _id: false })
+class RouteStop {
+    @Prop({ type: Types.ObjectId, ref: 'BusStop', required: true })
+    stopId: Types.ObjectId;
+
+    @Prop({ required: true, type: Number })
+    orderIndex: number;
+
+    @Prop({ required: true, type: Number })
+    distanceFromStart: number; // Khoảng cách từ điểm đầu (km)
+
+    @Prop({ required: true, type: Number })
+    estimatedTime: number; // Thời gian ước tính từ điểm đầu (phút)
+}
+
+@Schema({ collection: 'BusRoutes', timestamps: true })
+export class BusRoute {
+    @Prop({ required: true, type: String })
+    name: string;
+
+    @Prop({ type: String })
+    description: string;
+
+    @Prop({ required: true, type: [RouteStop] })
+    stops: RouteStop[];
+
+    @Prop({ required: true, type: [Position] })
+    routeCoordinates: Position[];
+
+    @Prop({ required: true, type: Number })
+    totalDistance: number; // Tổng khoảng cách (km)
+
+    @Prop({ required: true, type: Number })
+    estimatedDuration: number; // Tổng thời gian (phút)
+
+    @Prop({ type: Types.ObjectId, ref: 'VehicleCategory' })
+    vehicleCategory: Types.ObjectId;
+
+    @Prop({ required: true, type: String, enum: ['active', 'inactive'], default: 'active' })
+    status: string;
+
+    @Prop({ type: Number, required: true })
+    basePrice: number;
+}
+
+export const BusRouteSchema = SchemaFactory.createForClass(BusRoute);

--- a/backend/src/modules/bus-route/bus-route.service.ts
+++ b/backend/src/modules/bus-route/bus-route.service.ts
@@ -1,0 +1,58 @@
+import { Injectable, Inject, NotFoundException } from '@nestjs/common';
+import { IBusRouteService, IBusRouteRepository } from './bus-route.port';
+import { BusRouteDocument } from './bus-route.schema';
+import { CreateBusRouteDto, UpdateBusRouteDto } from './bus-route.dto';
+import { BUS_ROUTE_REPOSITORY } from './bus-route.di-token';
+
+@Injectable()
+export class BusRouteService implements IBusRouteService {
+    constructor(
+        @Inject(BUS_ROUTE_REPOSITORY)
+        private readonly busRouteRepository: IBusRouteRepository
+    ) {}
+
+    async createRoute(dto: CreateBusRouteDto): Promise<BusRouteDocument> {
+        return await this.busRouteRepository.create(dto);
+    }
+
+    async getAllRoutes(): Promise<BusRouteDocument[]> {
+        return await this.busRouteRepository.findAll();
+    }
+
+    async getRouteById(id: string): Promise<BusRouteDocument> {
+        const route = await this.busRouteRepository.findById(id);
+        if (!route) {
+            throw new NotFoundException('Bus route not found');
+        }
+        return route;
+    }
+
+    async updateRoute(id: string, dto: UpdateBusRouteDto): Promise<BusRouteDocument> {
+        const route = await this.busRouteRepository.update(id, dto);
+        if (!route) {
+            throw new NotFoundException('Bus route not found');
+        }
+        return route;
+    }
+
+    async deleteRoute(id: string): Promise<void> {
+        await this.getRouteById(id); // Check if exists
+        await this.busRouteRepository.delete(id);
+    }
+
+    async calculateFare(routeId: string, fromStopId: string, toStopId: string, numberOfSeats: number): Promise<number> {
+        const route = await this.getRouteById(routeId);
+        
+        const fromStop = route.stops.find(s => s.stopId.toString() === fromStopId);
+        const toStop = route.stops.find(s => s.stopId.toString() === toStopId);
+        
+        if (!fromStop || !toStop) {
+            throw new NotFoundException('Invalid bus stops');
+        }
+        
+        const distance = toStop.distanceFromStart - fromStop.distanceFromStart;
+        const baseFare = (distance / route.totalDistance) * route.basePrice;
+        
+        return Math.round(baseFare * numberOfSeats);
+    }
+}

--- a/backend/src/modules/bus-stop/bus-stop.controller.ts
+++ b/backend/src/modules/bus-stop/bus-stop.controller.ts
@@ -1,0 +1,136 @@
+import { Controller, Get, Post, Put, Delete, Body, Param, UseGuards, Inject } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { AuthGuard } from '../auth/auth.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { RolesGuard } from '../auth/role.guard';
+import { UserRole } from '../../share/enums';
+import { BUS_STOP_SERVICE } from './bus-stop.di-token';
+import { IBusStopService } from './bus-stop.port';
+import { CreateBusStopDto, UpdateBusStopDto } from './bus-stop.dto';
+import { ValidationErrorResponse } from 'src/common/swagger/responses';
+
+@ApiTags('bus-stops')
+@Controller('bus-stops')
+@UseGuards(AuthGuard, RolesGuard)
+@ApiBearerAuth('authorization')
+export class BusStopController {
+    constructor(
+        @Inject(BUS_STOP_SERVICE)
+        private readonly busStopService: IBusStopService
+    ) {}
+
+    @Post()
+    @Roles(UserRole.ADMIN)
+    @ApiOperation({ summary: 'Create new bus stop' })
+    @ApiResponse({ 
+        status: 201, 
+        description: 'Bus stop created successfully',
+        type: CreateBusStopDto 
+    })
+    @ApiResponse({ 
+        status: 400, 
+        description: 'Validation failed',
+        type: ValidationErrorResponse 
+    })
+    @ApiResponse({ 
+        status: 401, 
+        description: 'Unauthorized' 
+    })
+    @ApiResponse({ 
+        status: 403, 
+        description: 'Forbidden - Admin only' 
+    })
+    async createBusStop(@Body() dto: CreateBusStopDto) {
+        return await this.busStopService.createBusStop(dto);
+    }
+
+    @Get()
+    @ApiOperation({ summary: 'Get all bus stops' })
+     @ApiResponse({ 
+        status: 200, 
+        description: 'List of all bus stops',
+        type: [CreateBusStopDto]
+    })
+    @ApiResponse({ 
+        status: 401, 
+        description: 'Unauthorized' 
+    })
+    async getAllBusStops() {
+        return await this.busStopService.getAllBusStops();
+    }
+
+    @Get(':id')
+    @ApiOperation({ summary: 'Get bus stop by id' })
+    @ApiResponse({ 
+        status: 200, 
+        description: 'Bus stop details',
+        type: CreateBusStopDto
+    })
+    @ApiResponse({ 
+        status: 401, 
+        description: 'Unauthorized' 
+    })
+    @ApiResponse({ 
+        status: 404, 
+        description: 'Bus stop not found' 
+    })
+    async getBusStopById(@Param('id') id: string) {
+        return await this.busStopService.getBusStopById(id);
+    }
+
+    @Put(':id')
+    @Roles(UserRole.ADMIN)
+    @ApiOperation({ summary: 'Update bus stop' })
+     @ApiResponse({ 
+        status: 200, 
+        description: 'Bus stop updated successfully',
+        type: UpdateBusStopDto
+    })
+    @ApiResponse({ 
+        status: 400, 
+        description: 'Validation failed',
+        type: ValidationErrorResponse 
+    })
+    @ApiResponse({ 
+        status: 401, 
+        description: 'Unauthorized' 
+    })
+    @ApiResponse({ 
+        status: 403, 
+        description: 'Forbidden - Admin only' 
+    })
+    @ApiResponse({ 
+        status: 404, 
+        description: 'Bus stop not found' 
+    })
+    async updateBusStop(
+        @Param('id') id: string,
+        @Body() dto: UpdateBusStopDto
+    ) {
+        return await this.busStopService.updateBusStop(id, dto);
+    }
+
+    @Delete(':id')
+    @Roles(UserRole.ADMIN)
+    @ApiOperation({ summary: 'Delete bus stop' })
+     @ApiResponse({ 
+        status: 200, 
+        description: 'Bus stop deleted successfully' 
+    })
+    @ApiResponse({ 
+        status: 401, 
+        description: 'Unauthorized' 
+    })
+    @ApiResponse({ 
+        status: 403, 
+        description: 'Forbidden - Admin only' 
+    })
+    @ApiResponse({ 
+        status: 404, 
+        description: 'Bus stop not found' 
+    })
+    async deleteBusStop(@Param('id') id: string) {
+        await this.busStopService.deleteBusStop(id);
+        return { message: 'Bus stop deleted successfully' };
+    }
+}

--- a/backend/src/modules/bus-stop/bus-stop.di-token.ts
+++ b/backend/src/modules/bus-stop/bus-stop.di-token.ts
@@ -1,0 +1,2 @@
+export const BUS_STOP_REPOSITORY = Symbol('BusStopRepository');
+export const BUS_STOP_SERVICE = Symbol('BusStopService');

--- a/backend/src/modules/bus-stop/bus-stop.dto.ts
+++ b/backend/src/modules/bus-stop/bus-stop.dto.ts
@@ -1,0 +1,106 @@
+import { IsString, IsNotEmpty, IsEnum, IsObject, IsNumber } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PositionDto {
+    @ApiProperty({
+        description: 'Latitude of the bus stop',
+        example: 21.028511
+    })
+    @IsNumber()
+    lat: number;
+
+    @ApiProperty({
+        description: 'Longitude of the bus stop',
+        example: 105.804817
+    })
+    @IsNumber()
+    lng: number;
+}
+
+export class CreateBusStopDto {
+    @ApiProperty({
+        description: 'Name of the bus stop',
+        example: 'Vincom Center Ba Trieu'
+    })
+    @IsString()
+    @IsNotEmpty()
+    name: string;
+
+    @ApiProperty({
+        description: 'Description of the bus stop',
+        required: false,
+        example: 'Main entrance of Vincom Center Ba Trieu'
+    })
+    @IsString()
+    description?: string;
+
+    @ApiProperty({
+        description: 'Geographic position of the bus stop',
+        type: PositionDto
+    })
+    @IsObject()
+    @IsNotEmpty()
+    position: {
+        lat: number;
+        lng: number;
+    };
+
+    @ApiProperty({
+        description: 'Status of the bus stop',
+        enum: ['active', 'inactive'],
+        example: 'active'
+    })
+    @IsEnum(['active', 'inactive'])
+    status: string;
+
+    @ApiProperty({
+        description: 'Physical address of the bus stop',
+        required: false,
+        example: '191 Ba Trieu, Hai Ba Trung, Ha Noi'
+    })
+    @IsString()
+    address?: string;
+}
+
+export class UpdateBusStopDto {
+    @ApiProperty({
+        description: 'Name of the bus stop',
+        required: false,
+        example: 'Vincom Center Ba Trieu'
+    })
+    @IsString()
+    name?: string;
+
+    @ApiProperty({
+        description: 'Description of the bus stop',
+        required: false,
+        example: 'Main entrance of Vincom Center Ba Trieu'
+    })
+    @IsString()
+    description?: string;
+
+    @ApiProperty({
+        description: 'Geographic position of the bus stop',
+        required: false,
+        type: PositionDto
+    })
+    @IsObject()
+    position?: PositionDto;
+
+    @ApiProperty({
+        description: 'Status of the bus stop',
+        required: false,
+        enum: ['active', 'inactive'],
+        example: 'active'
+    })
+    @IsEnum(['active', 'inactive'])
+    status?: string;
+
+    @ApiProperty({
+        description: 'Physical address of the bus stop',
+        required: false,
+        example: '191 Ba Trieu, Hai Ba Trung, Ha Noi'
+    })
+    @IsString()
+    address?: string;
+}

--- a/backend/src/modules/bus-stop/bus-stop.module.ts
+++ b/backend/src/modules/bus-stop/bus-stop.module.ts
@@ -1,0 +1,37 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { BusStop, BusStopSchema } from './bus-stop.schema';
+import { BusStopController } from './bus-stop.controller';
+import { BusStopService } from './bus-stop.service';
+import { BusStopRepository } from './bus-stop.repo';
+import { BUS_STOP_REPOSITORY, BUS_STOP_SERVICE } from './bus-stop.di-token';
+import { KeytokenModule } from '../keytoken/keytoken.module';
+import { ShareModule } from 'src/share/share.module';
+
+const dependencies = [
+    {
+        provide: BUS_STOP_REPOSITORY,
+        useClass: BusStopRepository
+    },
+    {
+        provide: BUS_STOP_SERVICE,
+        useClass: BusStopService
+    }
+];
+
+@Module({
+    imports: [
+        MongooseModule.forFeature([
+            {
+                name: BusStop.name,
+                schema: BusStopSchema
+            }
+        ]),
+        KeytokenModule,
+        ShareModule
+    ],
+    controllers: [BusStopController],
+    providers: [...dependencies],
+    exports: [...dependencies]
+})
+export class BusStopModule {}

--- a/backend/src/modules/bus-stop/bus-stop.port.ts
+++ b/backend/src/modules/bus-stop/bus-stop.port.ts
@@ -1,0 +1,18 @@
+import { BusStopDocument } from './bus-stop.schema';
+import { CreateBusStopDto, UpdateBusStopDto } from './bus-stop.dto';
+
+export interface IBusStopRepository {
+    create(dto: CreateBusStopDto): Promise<BusStopDocument>;
+    findAll(): Promise<BusStopDocument[]>;
+    findById(id: string): Promise<BusStopDocument>;
+    update(id: string, dto: UpdateBusStopDto): Promise<BusStopDocument>;
+    delete(id: string): Promise<void>;
+}
+
+export interface IBusStopService {
+    createBusStop(dto: CreateBusStopDto): Promise<BusStopDocument>;
+    getAllBusStops(): Promise<BusStopDocument[]>;
+    getBusStopById(id: string): Promise<BusStopDocument>;
+    updateBusStop(id: string, dto: UpdateBusStopDto): Promise<BusStopDocument>;
+    deleteBusStop(id: string): Promise<void>;
+}

--- a/backend/src/modules/bus-stop/bus-stop.repo.ts
+++ b/backend/src/modules/bus-stop/bus-stop.repo.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { BusStop, BusStopDocument } from './bus-stop.schema';
+import { IBusStopRepository } from './bus-stop.port';
+import { CreateBusStopDto, UpdateBusStopDto } from './bus-stop.dto';
+
+@Injectable()
+export class BusStopRepository implements IBusStopRepository {
+    constructor(
+        @InjectModel(BusStop.name)
+        private readonly busStopModel: Model<BusStop>
+    ) {}
+
+    async create(dto: CreateBusStopDto): Promise<BusStopDocument> {
+        const busStop = new this.busStopModel(dto);
+        return await busStop.save();
+    }
+
+    async findAll(): Promise<BusStopDocument[]> {
+        return await this.busStopModel.find().exec();
+    }
+
+    async findById(id: string): Promise<BusStopDocument> {
+        return await this.busStopModel.findById(id).exec();
+    }
+
+    async update(id: string, dto: UpdateBusStopDto): Promise<BusStopDocument> {
+        return await this.busStopModel.findByIdAndUpdate(id, dto, { new: true }).exec();
+    }
+
+    async delete(id: string): Promise<void> {
+        await this.busStopModel.findByIdAndDelete(id).exec();
+    }
+}

--- a/backend/src/modules/bus-stop/bus-stop.schema.ts
+++ b/backend/src/modules/bus-stop/bus-stop.schema.ts
@@ -1,0 +1,33 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+
+export type BusStopDocument = HydratedDocument<BusStop>;
+
+@Schema({ _id: false })
+class Position {
+    @Prop({ required: true, type: Number })
+    lat: number;
+
+    @Prop({ required: true, type: Number })
+    lng: number;
+}
+
+@Schema({ collection: 'BusStops', timestamps: true })
+export class BusStop {
+    @Prop({ required: true, type: String })
+    name: string;
+
+    @Prop({ type: String })
+    description: string;
+
+    @Prop({ required: true, type: Position })
+    position: Position;
+
+    @Prop({ required: true, type: String, enum: ['active', 'inactive'], default: 'active' })
+    status: string;
+
+    @Prop({ type: String })
+    address: string;
+}
+
+export const BusStopSchema = SchemaFactory.createForClass(BusStop);

--- a/backend/src/modules/bus-stop/bus-stop.service.ts
+++ b/backend/src/modules/bus-stop/bus-stop.service.ts
@@ -1,0 +1,42 @@
+import { Injectable, Inject, NotFoundException } from '@nestjs/common';
+import { IBusStopService, IBusStopRepository } from './bus-stop.port';
+import { BusStopDocument } from './bus-stop.schema';
+import { CreateBusStopDto, UpdateBusStopDto } from './bus-stop.dto';
+import { BUS_STOP_REPOSITORY } from './bus-stop.di-token';
+
+@Injectable()
+export class BusStopService implements IBusStopService {
+    constructor(
+        @Inject(BUS_STOP_REPOSITORY)
+        private readonly busStopRepository: IBusStopRepository
+    ) {}
+
+    async createBusStop(dto: CreateBusStopDto): Promise<BusStopDocument> {
+        return await this.busStopRepository.create(dto);
+    }
+
+    async getAllBusStops(): Promise<BusStopDocument[]> {
+        return await this.busStopRepository.findAll();
+    }
+
+    async getBusStopById(id: string): Promise<BusStopDocument> {
+        const busStop = await this.busStopRepository.findById(id);
+        if (!busStop) {
+            throw new NotFoundException('Bus stop not found');
+        }
+        return busStop;
+    }
+
+    async updateBusStop(id: string, dto: UpdateBusStopDto): Promise<BusStopDocument> {
+        const busStop = await this.busStopRepository.update(id, dto);
+        if (!busStop) {
+            throw new NotFoundException('Bus stop not found');
+        }
+        return busStop;
+    }
+
+    async deleteBusStop(id: string): Promise<void> {
+        await this.getBusStopById(id); 
+        await this.busStopRepository.delete(id);
+    }
+}

--- a/backend/src/modules/trip/trip.controller.ts
+++ b/backend/src/modules/trip/trip.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpCode, HttpStatus, Inject, Request, UseGuards } from "@nestjs/common";
+import { Body, Controller, Get, HttpCode, HttpStatus, Inject, Post, Request, UseGuards } from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { AuthGuard } from "src/modules/auth/auth.guard";
 import { Roles } from "src/modules/auth/decorators/roles.decorator";
@@ -6,6 +6,7 @@ import { RolesGuard } from "src/modules/auth/role.guard";
 import { TRIP_SERVICE } from "src/modules/trip/trip.di-token";
 import { ITripService } from "src/modules/trip/trip.port";
 import { UserRole } from "src/share/enums";
+
 
 @ApiTags('trip')
 @Controller('trip')
@@ -38,5 +39,27 @@ export class TripController {
         @Request() req,
     ) {
         return await this.tripService.getPersonalDriverTrip(req.user._id)
+    }
+
+
+    @Post('calculate-bus-route-fare')
+    @HttpCode(HttpStatus.OK)
+    @UseGuards(AuthGuard)
+    @ApiBearerAuth('authorization')
+    @ApiOperation({ summary: 'Calculate bus route fare' })
+    async calculateBusRouteFare(
+        @Body() data: {
+            routeId: string;
+            fromStopId: string;
+            toStopId: string;
+            numberOfSeats: number;
+        }
+    ) {
+        return await this.tripService.calculateBusRouteFare(
+            data.routeId,
+            data.fromStopId,
+            data.toStopId,
+            data.numberOfSeats
+        );
     }
 }

--- a/backend/src/modules/trip/trip.dto.ts
+++ b/backend/src/modules/trip/trip.dto.ts
@@ -15,7 +15,8 @@ export interface ICreateTripDto {
     | BookingHourPayloadDto
     | BookingScenicRoutePayloadDto
     | BookingDestinationPayloadDto
-    | BookingSharePayloadDto;
+    | BookingSharePayloadDto
+    | BookingBusRoutePayloadDto;
 }
 
 
@@ -56,6 +57,17 @@ export class BookingScenicRoutePayloadDto {
         startPoint: Position;
         distanceEstimate: number;
         distance: number
+    }
+}
+
+export class BookingBusRoutePayloadDto {
+    bookingBusRoute: {
+        routeId: string;
+        fromStopId: string;
+        toStopId: string;
+        distanceEstimate: number;
+        distance: number;
+        numberOfSeat: number;
     }
 }
 

--- a/backend/src/modules/trip/trip.module.ts
+++ b/backend/src/modules/trip/trip.module.ts
@@ -8,6 +8,7 @@ import { TripRepository } from "src/modules/trip/trip.repo";
 import { Trip, TripSchema } from "src/modules/trip/trip.schema";
 import { TripService } from "src/modules/trip/trip.service";
 import { ShareModule } from "src/share/share.module";
+import { BusRouteModule } from '../bus-route/bus-route.module';
 
 const dependencies = [
     {
@@ -30,7 +31,8 @@ const dependencies = [
         ]),
         DriverScheduleModule,
         ShareModule,
-        KeytokenModule
+        KeytokenModule,
+         BusRouteModule,
     ],
     controllers: [TripController],
     providers: [...dependencies],

--- a/backend/src/modules/trip/trip.port.ts
+++ b/backend/src/modules/trip/trip.port.ts
@@ -18,6 +18,12 @@ export interface ITripService {
     checkTrip(createTripDto: ICreateTripDto): Promise<boolean>;
     getPersonalCustomerTrip(customerId: string): Promise<TripDocument[]>
     getPersonalDriverTrip(driverId: string): Promise<TripDocument[]>
+      calculateBusRouteFare(
+        routeId: string,
+        fromStopId: string,
+        toStopId: string,
+        numberOfSeats: number
+    ): Promise<number>;
     // getTripById(id: string): Promise<Trip>;
     // getDriverTrips(driverId: string): Promise<Trip[]>;
 }

--- a/backend/src/modules/trip/trip.schema.ts
+++ b/backend/src/modules/trip/trip.schema.ts
@@ -102,6 +102,14 @@ export class Trip {
             distanceEstimate: number;
             distance: number
         };
+        bookingBusRoute?: {
+        routeId: Types.ObjectId;
+        fromStopId: Types.ObjectId;
+        toStopId: Types.ObjectId;
+        distanceEstimate: number;
+        distance: number;
+        numberOfSeat: number;
+    };
     };
 
     @Prop({ type: Number })
@@ -161,7 +169,13 @@ TripSchema.pre<Trip>('validate', function (next) {
             return payload.bookingShare.numberOfSeat &&
                 payload.bookingShare.startPoint &&
                 payload.bookingShare.endPoint;
-        }
+        },
+        [ServiceType.BOOKING_BUS_ROUTE]: () => {
+            if (!payload.bookingBusRoute) return false;
+            return payload.bookingBusRoute.routeId &&
+                payload.bookingBusRoute.fromStopId &&
+                payload.bookingBusRoute.toStopId;
+}
     };
 
     if (!validators[serviceType]?.()) {

--- a/backend/src/modules/trip/trip.service.ts
+++ b/backend/src/modules/trip/trip.service.ts
@@ -47,6 +47,8 @@ export class TripService implements ITripService {
             }, HttpStatus.BAD_REQUEST);
         }
 
+        //add
+
         if (createTripDto.serviceType === ServiceType.BOOKING_BUS_ROUTE) {
             const payload = createTripDto.servicePayload as BookingBusRoutePayloadDto;
             const busRoute = await this.busRouteRepository.findById(payload.bookingBusRoute.routeId);

--- a/backend/src/modules/trip/trip.service.ts
+++ b/backend/src/modules/trip/trip.service.ts
@@ -3,11 +3,14 @@ import { DRIVERSCHEDULE_REPOSITORY } from "src/modules/driver-schedule/driver-sc
 import { IDriverScheduleRepository } from "src/modules/driver-schedule/driver-schedule.port";
 import { DriverSchedule } from "src/modules/driver-schedule/driver-schedule.schema";
 import { TRIP_REPOSITORY } from "src/modules/trip/trip.di-token";
-import { ICreateTripDto } from "src/modules/trip/trip.dto";
+import { BookingBusRoutePayloadDto, ICreateTripDto } from "src/modules/trip/trip.dto";
 import { ITripRepository, ITripService } from "src/modules/trip/trip.port";
 import { TripDocument } from "src/modules/trip/trip.schema";
 
-import { DriverSchedulesStatus, Shift, ShiftHours } from "src/share/enums";
+import { DriverSchedulesStatus, ServiceType, Shift, ShiftHours } from "src/share/enums";
+
+import { BUS_ROUTE_REPOSITORY } from '../bus-route/bus-route.di-token';
+import { IBusRouteRepository } from '../bus-route/bus-route.port';
 
 
 @Injectable()
@@ -16,7 +19,9 @@ export class TripService implements ITripService {
         @Inject(TRIP_REPOSITORY)
         private readonly tripRepository: ITripRepository,
         @Inject(DRIVERSCHEDULE_REPOSITORY)
-        private readonly driverScheduleRepository: IDriverScheduleRepository
+        private readonly driverScheduleRepository: IDriverScheduleRepository,
+        @Inject(BUS_ROUTE_REPOSITORY)
+        private readonly busRouteRepository: IBusRouteRepository
     ) { }
 
     async createTrip(createTripDto: ICreateTripDto): Promise<TripDocument> {
@@ -40,6 +45,45 @@ export class TripService implements ITripService {
                 message: 'driver Schedule is not valid',
                 vnMesage: 'Không có lịch phù hợp',
             }, HttpStatus.BAD_REQUEST);
+        }
+
+        if (createTripDto.serviceType === ServiceType.BOOKING_BUS_ROUTE) {
+            const payload = createTripDto.servicePayload as BookingBusRoutePayloadDto;
+            const busRoute = await this.busRouteRepository.findById(payload.bookingBusRoute.routeId);
+            
+            if (!busRoute) {
+                throw new HttpException({
+                    statusCode: HttpStatus.BAD_REQUEST,
+                    message: 'Bus route not found',
+                    vnMessage: 'Không tìm thấy tuyến xe',
+                }, HttpStatus.BAD_REQUEST);
+            }
+
+            // Validate stops
+            const fromStop = busRoute.stops.find(s => s.stopId.toString() === payload.bookingBusRoute.fromStopId);
+            const toStop = busRoute.stops.find(s => s.stopId.toString() === payload.bookingBusRoute.toStopId);
+
+            if (!fromStop || !toStop) {
+                throw new HttpException({
+                    statusCode: HttpStatus.BAD_REQUEST,
+                    message: 'Invalid bus stops',
+                    vnMessage: 'Trạm dừng không hợp lệ',
+                }, HttpStatus.BAD_REQUEST);
+            }
+
+            if (fromStop.orderIndex >= toStop.orderIndex) {
+                throw new HttpException({
+                    statusCode: HttpStatus.BAD_REQUEST,
+                    message: 'Invalid stop order',
+                    vnMessage: 'Thứ tự trạm không hợp lệ',
+                }, HttpStatus.BAD_REQUEST);
+            }
+
+            // Calculate estimated duration based on stops
+            const duration = toStop.estimatedTime - fromStop.estimatedTime;
+            createTripDto.timeEndEstimate = new Date(
+                createTripDto.timeStartEstimate.getTime() + duration * 60 * 1000
+            );
         }
 
         const { timeStart, timeEnd } = await this.validateTimeRange(createTripDto, driverSchedule);
@@ -127,6 +171,22 @@ export class TripService implements ITripService {
 
     async getPersonalDriverTrip(driverId: string): Promise<TripDocument[]> {
         return await this.tripRepository.find({ driverId }, [])
+    }
+
+     async calculateBusRouteFare(
+        routeId: string, 
+        fromStopId: string, 
+        toStopId: string,
+        numberOfSeats: number
+    ): Promise<number> {
+        const route = await this.busRouteRepository.findById(routeId);
+        const fromStop = route.stops.find(s => s.stopId.toString() === fromStopId);
+        const toStop = route.stops.find(s => s.stopId.toString() === toStopId);
+        
+        const distance = toStop.distanceFromStart - fromStop.distanceFromStart;
+        const baseFare = (distance / route.totalDistance) * route.basePrice;
+        
+        return Math.round(baseFare * numberOfSeats);
     }
 
 }

--- a/backend/src/share/enums/service-type.enum.ts
+++ b/backend/src/share/enums/service-type.enum.ts
@@ -2,6 +2,7 @@ export enum ServiceType {
     BOOKING_HOUR = 'booking_hour',
     BOOKING_SCENIC_ROUTE = 'booking_scenic_route',
     BOOKING_SHARE = 'booking_share',
-    BOOKING_DESTINATION = 'booking_destination'
+    BOOKING_DESTINATION = 'booking_destination',
+    BOOKING_BUS_ROUTE = 'booking_bus_route'
 }
 


### PR DESCRIPTION
- Add bus stop management module with CRUD operations
- Add bus route management module with CRUD operations
- Implement fare calculation based on distance between stops
- Add Swagger documentation for new APIs
- Add validation and error handling
- Add role-based access control for admin operations

Technical changes:
- Create BusStop and BusRoute schemas with MongoDB
- Implement repository pattern for data access
- Add DTOs with validation rules
- Add interfaces and dependency injection tokens
- Integrate with existing auth system
- Add route fare calculation logic